### PR TITLE
Update Dockerfile for the new voice cloning system.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,27 +1,29 @@
-FROM debian:stable
+FROM python:3.10-bookworm
 
 # Install system packages
-RUN apt update && apt install -y git pip
+RUN DEBIAN_FRONTEND=noninteractive apt update && apt install -y \
+	ffmpeg 
+
 
 # Create non-root user
-RUN useradd -m -d /bark bark
+RUN useradd -m -d /bark bark 
+
+# Copy project files
+COPY ./ /bark/bark-gui
+
+# Correct permission for non-root user
+RUN chown bark:bark -R /bark/bark-gui
 
 # Run as new user
 USER bark
-WORKDIR /bark
-
-# Clone git repo
-RUN git clone https://github.com/C0untFloyd/bark-gui 
-
-# Switch to git directory
 WORKDIR /bark/bark-gui
 
 # Append pip bin path to PATH
 ENV PATH=$PATH:/bark/.local/bin
 
 # Install dependancies
-RUN pip install .
-RUN pip install -r requirements.txt
+RUN pip install --no-cache-dir . &&\
+	pip install --no-cache-dir -r requirements.txt
 
 # List on all addresses, since we are in a container.
 RUN sed -i "s/server_name: ''/server_name: 0.0.0.0/g" ./config.yaml


### PR DESCRIPTION
Fixing some of the issues created by the new voice cloning system in the Dockerfile. as mentioned in #40 . I've tagged a specific python version as the base image, so if that ever needs to be updated, it should be easy peasy. I changed it to copy the project files from the cloned directory, rather than pulling from the git repo during build, better for reproducibility. I added ffmpeg into the image to handle audio files other than pure .wav.

I cannot test CUDA, as I don't have any hardware to test on. CPU speech generation works perfectly, and feels faster, though I've not run benchmarks on it. However, the actual voice cloning features error on CPU. 

```
Traceback (most recent call last):
  File "/bark/.local/lib/python3.10/site-packages/gradio/routes.py", line 437, in run_predict
    output = await app.get_blocks().process_api(
  File "/bark/.local/lib/python3.10/site-packages/gradio/blocks.py", line 1352, in process_api
    result = await self.call_function(
  File "/bark/.local/lib/python3.10/site-packages/gradio/blocks.py", line 1077, in call_function
    prediction = await anyio.to_thread.run_sync(
  File "/bark/.local/lib/python3.10/site-packages/anyio/to_thread.py", line 33, in run_sync
    return await get_asynclib().run_sync_in_worker_thread(
  File "/bark/.local/lib/python3.10/site-packages/anyio/_backends/_asyncio.py", line 877, in run_sync_in_worker_thread
    return await future
  File "/bark/.local/lib/python3.10/site-packages/anyio/_backends/_asyncio.py", line 807, in run
    result = context.run(func, *args)
  File "/bark/.local/lib/python3.10/site-packages/gradio/helpers.py", line 602, in tracked_fn
    response = fn(*args)
  File "/bark/bark-gui/cloning/clonevoice.py", line 34, in clone_voice
    tokenizer = CustomTokenizer.load_from_checkpoint(f'./models/hubert/{tokenizer_lang}_tokenizer.pth').to(device)  # Automatically uses the right layers
  File "/bark/bark-gui/bark/hubert/customtokenizer.py", line 121, in load_from_checkpoint
    model.load_state_dict(torch.load(path))
  File "/bark/.local/lib/python3.10/site-packages/torch/serialization.py", line 809, in load
    return _load(opened_zipfile, map_location, pickle_module, **pickle_load_args)
  File "/bark/.local/lib/python3.10/site-packages/torch/serialization.py", line 1172, in _load
    result = unpickler.load()
  File "/bark/.local/lib/python3.10/site-packages/torch/serialization.py", line 1142, in persistent_load
    typed_storage = load_tensor(dtype, nbytes, key, _maybe_decode_ascii(location))
  File "/bark/.local/lib/python3.10/site-packages/torch/serialization.py", line 1116, in load_tensor
    wrap_storage=restore_location(storage, location),
  File "/bark/.local/lib/python3.10/site-packages/torch/serialization.py", line 217, in default_restore_location
    result = fn(storage, location)
  File "/bark/.local/lib/python3.10/site-packages/torch/serialization.py", line 182, in _cuda_deserialize
    device = validate_cuda_device(location)
  File "/bark/.local/lib/python3.10/site-packages/torch/serialization.py", line 166, in validate_cuda_device
    raise RuntimeError('Attempting to deserialize object on a CUDA '
RuntimeError: Attempting to deserialize object on a CUDA device but torch.cuda.is_available() is False. If you are running on a CPU-only machine, please use torch.load with map_location=torch.device('cpu') to map your storages to the CPU.
```
During startup it does display forcecpu=True, so maybe something isn't respecting the config?

During the build, I do get this:
`INFO | fairseq.tasks.text_to_speech | Please install tensorboardX: pip install tensorboardX`
Should this be added as a dependency?

You are free to delay this merge until these are resolved, but other than voice cloning, this image works.