### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,8 +20,8 @@ WORKDIR /bark/bark-gui
 ENV PATH=$PATH:/bark/.local/bin
 
 # Install dependancies
-RUN pip install .
-RUN pip install -r requirements.txt
+RUN pip install . --break-system-packages
+RUN pip install -r requirements.txt --break-system-packages
 
 # List on all addresses, since we are in a container.
 RUN sed -i "s/server_name: ''/server_name: 0.0.0.0/g" ./config.yaml


### PR DESCRIPTION
Fix the issue of "error: externally-managed-environment" during building docker images as debian has adopted PEP 668 – Marking Python base environments as “externally managed”.